### PR TITLE
feat: word-extractor + contentStream migration for Office document reading

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,8 @@ Claude Desktop has a practical limit of ~55 tools per MCP server. This project e
 
 `MCP_MODULES` filters which modules the adapter exposes. Omit it to expose all 117 tools (works with clients that have no tool cap).
 
+Set `MCP_DEBUG=1` in the `env` block to enable diagnostic logging to stderr — useful for troubleshooting tool dispatch issues.
+
 Restart Claude Desktop. Ask: *"What's on my calendar today?"* or *"Create an Excel workbook with a budget table."*
 
 ---
@@ -270,7 +272,7 @@ Work directly with Excel workbooks stored in OneDrive or SharePoint — no file 
 
 ### Word (5)
 
-Create, read, and convert Word documents. Documents are created from structured JSON and stored in OneDrive. Reading uses mammoth for HTML/text extraction.
+Create, read, and convert Word documents. Documents are created from structured JSON and stored in OneDrive. Reading uses a multi-library fallback chain: mammoth (best HTML for .docx) → word-extractor (handles both .doc and .docx) → webUrl fallback. Binary downloads use the Graph beta `/contentStream` endpoint for reliable binary transfer.
 
 | Tool | Description |
 |---|---|
@@ -280,9 +282,11 @@ Create, read, and convert Word documents. Documents are created from structured 
 | `getWordDocumentAsHtml` | Convert document content to HTML |
 | `convertDocumentToPdf` | Convert a Word document to PDF |
 
+> **Note:** Some SharePoint tenants convert uploaded .docx files to OLE2 binary format within seconds of upload. When this happens, client-side parsing libraries cannot read the file. The server gracefully falls back to returning the `webUrl` so the user can open the document in the browser.
+
 ### PowerPoint (4)
 
-Create, read, and convert PowerPoint presentations. Presentations are built from structured slide data and stored in OneDrive.
+Create, read, and convert PowerPoint presentations. Presentations are built from structured slide data and stored in OneDrive. Reading uses Graph HTML conversion with jszip fallback for slide-level text extraction.
 
 | Tool | Description |
 |---|---|
@@ -482,14 +486,19 @@ See [docs/azure-deployment.md](docs/azure-deployment.md) for CI/CD deployment wi
 
 ```
 MCP-Microsoft-Office/
-├── mcp-adapter.cjs          MCP protocol adapter (runs locally)
+├── mcp-adapter.cjs          MCP protocol adapter (runs locally with Claude Desktop)
 ├── src/
 │   ├── api/                 Express routes and controllers
-│   ├── auth/                MSAL authentication
-│   ├── core/                Services (cache, storage, tools)
+│   ├── auth/                MSAL authentication (OAuth2, ROPC, token exchange)
+│   ├── core/                Services (cache, storage, tools, error handling)
 │   ├── graph/               Microsoft Graph API services
+│   │   ├── graph-client.cjs   HTTP client with retry, binary support, sessions
+│   │   ├── files-service.cjs  OneDrive file operations
+│   │   ├── excel-service.cjs  Workbook API (sessions, ranges, tables, functions)
+│   │   ├── word-service.cjs   Word create/read (docx + mammoth + word-extractor)
+│   │   └── powerpoint-service.cjs  PPT create/read (pptxgenjs + jszip)
 │   └── modules/             Feature modules (mail, calendar, excel, word, powerpoint, etc.)
-├── public/                  Web UI
+├── public/                  Web UI for authentication
 └── tests/                   E2E test suite (gitignored)
 ```
 

--- a/mcp-adapter.cjs
+++ b/mcp-adapter.cjs
@@ -2486,6 +2486,17 @@ async function handleRequest(msg) {
                         mcpTools = toolsResult.tools.map(formatTool);
                     }
 
+                    // Apply MCP_MODULES filter if set
+                    if (_allowedModules) {
+                        const allowedTools = new Set();
+                        for (const mod of _allModules) {
+                            if (_allowedModules.has(mod.id)) {
+                                (mod.capabilities || []).forEach(c => allowedTools.add(c));
+                            }
+                        }
+                        mcpTools = mcpTools.filter(t => allowedTools.has(t.name));
+                    }
+
                     // Filter tools based on user's permissions
                     const filteredTools = await filterToolsByPermissions(mcpTools);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,6 @@
                 "node-cache": "^5.1.2",
                 "node-fetch": "^2.7.0",
                 "node-gyp": "^11.2.0",
-                "officeparser": "^6.0.7",
                 "pg": "^8.11.3",
                 "pg-pool": "^3.6.2",
                 "pptxgenjs": "^4.0.1",
@@ -1666,16 +1665,6 @@
                 "node": ">=6.9.0"
             }
         },
-        "node_modules/@borewit/text-codec": {
-            "version": "0.2.2",
-            "resolved": "https://registry.npmjs.org/@borewit/text-codec/-/text-codec-0.2.2.tgz",
-            "integrity": "sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ==",
-            "license": "MIT",
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/Borewit"
-            }
-        },
         "node_modules/@colors/colors": {
             "version": "1.6.0",
             "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.6.0.tgz",
@@ -1850,256 +1839,6 @@
                 }
             }
         },
-        "node_modules/@napi-rs/canvas": {
-            "version": "0.1.97",
-            "resolved": "https://registry.npmjs.org/@napi-rs/canvas/-/canvas-0.1.97.tgz",
-            "integrity": "sha512-8cFniXvrIEnVwuNSRCW9wirRZbHvrD3JVujdS2P5n5xiJZNZMOZcfOvJ1pb66c7jXMKHHglJEDVJGbm8XWFcXQ==",
-            "license": "MIT",
-            "optional": true,
-            "workspaces": [
-                "e2e/*"
-            ],
-            "engines": {
-                "node": ">= 10"
-            },
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/Brooooooklyn"
-            },
-            "optionalDependencies": {
-                "@napi-rs/canvas-android-arm64": "0.1.97",
-                "@napi-rs/canvas-darwin-arm64": "0.1.97",
-                "@napi-rs/canvas-darwin-x64": "0.1.97",
-                "@napi-rs/canvas-linux-arm-gnueabihf": "0.1.97",
-                "@napi-rs/canvas-linux-arm64-gnu": "0.1.97",
-                "@napi-rs/canvas-linux-arm64-musl": "0.1.97",
-                "@napi-rs/canvas-linux-riscv64-gnu": "0.1.97",
-                "@napi-rs/canvas-linux-x64-gnu": "0.1.97",
-                "@napi-rs/canvas-linux-x64-musl": "0.1.97",
-                "@napi-rs/canvas-win32-arm64-msvc": "0.1.97",
-                "@napi-rs/canvas-win32-x64-msvc": "0.1.97"
-            }
-        },
-        "node_modules/@napi-rs/canvas-android-arm64": {
-            "version": "0.1.97",
-            "resolved": "https://registry.npmjs.org/@napi-rs/canvas-android-arm64/-/canvas-android-arm64-0.1.97.tgz",
-            "integrity": "sha512-V1c/WVw+NzH8vk7ZK/O8/nyBSCQimU8sfMsB/9qeSvdkGKNU7+mxy/bIF0gTgeBFmHpj30S4E9WHMSrxXGQuVQ==",
-            "cpu": [
-                "arm64"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "android"
-            ],
-            "engines": {
-                "node": ">= 10"
-            },
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/Brooooooklyn"
-            }
-        },
-        "node_modules/@napi-rs/canvas-darwin-arm64": {
-            "version": "0.1.97",
-            "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-arm64/-/canvas-darwin-arm64-0.1.97.tgz",
-            "integrity": "sha512-ok+SCEF4YejcxuJ9Rm+WWunHHpf2HmiPxfz6z1a/NFQECGXtsY7A4B8XocK1LmT1D7P174MzwPF9Wy3AUAwEPw==",
-            "cpu": [
-                "arm64"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "darwin"
-            ],
-            "engines": {
-                "node": ">= 10"
-            },
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/Brooooooklyn"
-            }
-        },
-        "node_modules/@napi-rs/canvas-darwin-x64": {
-            "version": "0.1.97",
-            "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-x64/-/canvas-darwin-x64-0.1.97.tgz",
-            "integrity": "sha512-PUP6e6/UGlclUvAQNnuXCcnkpdUou6VYZfQOQxExLp86epOylmiwLkqXIvpFmjoTEDmPmXrI+coL/9EFU1gKPA==",
-            "cpu": [
-                "x64"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "darwin"
-            ],
-            "engines": {
-                "node": ">= 10"
-            },
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/Brooooooklyn"
-            }
-        },
-        "node_modules/@napi-rs/canvas-linux-arm-gnueabihf": {
-            "version": "0.1.97",
-            "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm-gnueabihf/-/canvas-linux-arm-gnueabihf-0.1.97.tgz",
-            "integrity": "sha512-XyXH2L/cic8eTNtbrXCcvqHtMX/nEOxN18+7rMrAM2XtLYC/EB5s0wnO1FsLMWmK+04ZSLN9FBGipo7kpIkcOw==",
-            "cpu": [
-                "arm"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">= 10"
-            },
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/Brooooooklyn"
-            }
-        },
-        "node_modules/@napi-rs/canvas-linux-arm64-gnu": {
-            "version": "0.1.97",
-            "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-gnu/-/canvas-linux-arm64-gnu-0.1.97.tgz",
-            "integrity": "sha512-Kuq/M3djq0K8ktgz6nPlK7Ne5d4uWeDxPpyKWOjWDK2RIOhHVtLtyLiJw2fuldw7Vn4mhw05EZXCEr4Q76rs9w==",
-            "cpu": [
-                "arm64"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">= 10"
-            },
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/Brooooooklyn"
-            }
-        },
-        "node_modules/@napi-rs/canvas-linux-arm64-musl": {
-            "version": "0.1.97",
-            "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-musl/-/canvas-linux-arm64-musl-0.1.97.tgz",
-            "integrity": "sha512-kKmSkQVnWeqg7qdsiXvYxKhAFuHz3tkBjW/zyQv5YKUPhotpaVhpBGv5LqCngzyuRV85SXoe+OFj+Tv0a0QXkQ==",
-            "cpu": [
-                "arm64"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">= 10"
-            },
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/Brooooooklyn"
-            }
-        },
-        "node_modules/@napi-rs/canvas-linux-riscv64-gnu": {
-            "version": "0.1.97",
-            "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-riscv64-gnu/-/canvas-linux-riscv64-gnu-0.1.97.tgz",
-            "integrity": "sha512-Jc7I3A51jnEOIAXeLsN/M/+Z28LUeakcsXs07FLq9prXc0eYOtVwsDEv913Gr+06IRo34gJJVgT0TXvmz+N2VA==",
-            "cpu": [
-                "riscv64"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">= 10"
-            },
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/Brooooooklyn"
-            }
-        },
-        "node_modules/@napi-rs/canvas-linux-x64-gnu": {
-            "version": "0.1.97",
-            "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-gnu/-/canvas-linux-x64-gnu-0.1.97.tgz",
-            "integrity": "sha512-iDUBe7AilfuBSRbSa8/IGX38Mf+iCSBqoVKLSQ5XaY2JLOaqz1TVyPFEyIck7wT6mRQhQt5sN6ogfjIDfi74tg==",
-            "cpu": [
-                "x64"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">= 10"
-            },
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/Brooooooklyn"
-            }
-        },
-        "node_modules/@napi-rs/canvas-linux-x64-musl": {
-            "version": "0.1.97",
-            "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-musl/-/canvas-linux-x64-musl-0.1.97.tgz",
-            "integrity": "sha512-AKLFd/v0Z5fvgqBDqhvqtAdx+fHMJ5t9JcUNKq4FIZ5WH+iegGm8HPdj00NFlCSnm83Fp3Ln8I2f7uq1aIiWaA==",
-            "cpu": [
-                "x64"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">= 10"
-            },
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/Brooooooklyn"
-            }
-        },
-        "node_modules/@napi-rs/canvas-win32-arm64-msvc": {
-            "version": "0.1.97",
-            "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-arm64-msvc/-/canvas-win32-arm64-msvc-0.1.97.tgz",
-            "integrity": "sha512-u883Yr6A6fO7Vpsy9YE4FVCIxzzo5sO+7pIUjjoDLjS3vQaNMkVzx5bdIpEL+ob+gU88WDK4VcxYMZ6nmnoX9A==",
-            "cpu": [
-                "arm64"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "win32"
-            ],
-            "engines": {
-                "node": ">= 10"
-            },
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/Brooooooklyn"
-            }
-        },
-        "node_modules/@napi-rs/canvas-win32-x64-msvc": {
-            "version": "0.1.97",
-            "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-x64-msvc/-/canvas-win32-x64-msvc-0.1.97.tgz",
-            "integrity": "sha512-sWtD2EE3fV0IzN+iiQUqr/Q1SwqWhs2O1FKItFlxtdDkikpEj5g7DKQpY3x55H/MAOnL8iomnlk3mcEeGiUMoQ==",
-            "cpu": [
-                "x64"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "win32"
-            ],
-            "engines": {
-                "node": ">= 10"
-            },
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/Brooooooklyn"
-            }
-        },
         "node_modules/@npmcli/agent": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/@npmcli/agent/-/agent-3.0.0.tgz",
@@ -2204,29 +1943,6 @@
             "resolved": "https://registry.npmjs.org/@sideway/pinpoint/-/pinpoint-2.0.0.tgz",
             "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==",
             "license": "BSD-3-Clause"
-        },
-        "node_modules/@tokenizer/inflate": {
-            "version": "0.4.1",
-            "resolved": "https://registry.npmjs.org/@tokenizer/inflate/-/inflate-0.4.1.tgz",
-            "integrity": "sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA==",
-            "license": "MIT",
-            "dependencies": {
-                "debug": "^4.4.3",
-                "token-types": "^6.1.1"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/Borewit"
-            }
-        },
-        "node_modules/@tokenizer/token": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
-            "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==",
-            "license": "MIT"
         },
         "node_modules/@types/http-proxy": {
             "version": "1.17.16",
@@ -2806,12 +2522,6 @@
             "integrity": "sha512-iD3898SR7sWVRHbiQv+sHUtHnMvC1o3nW5rAcqnq3uOn07DSAppZYUkIGslDz6gXC7HfunPe7YVBgoEJASPcHA==",
             "license": "MIT"
         },
-        "node_modules/bmp-js": {
-            "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/bmp-js/-/bmp-js-0.1.0.tgz",
-            "integrity": "sha512-vHdS19CnY3hwiNdkaqk93DvjVLfbEcI8mys4UjuWrlX1haDmroo8o4xCzh4wD6DGV6HxRCyauwhHRqMTfERtjw==",
-            "license": "MIT"
-        },
         "node_modules/body-parser": {
             "version": "2.2.2",
             "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
@@ -3108,12 +2818,6 @@
             "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
             "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
             "license": "BSD-3-Clause"
-        },
-        "node_modules/buffer-from": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
-            "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-            "license": "MIT"
         },
         "node_modules/builtins": {
             "version": "5.1.0",
@@ -3611,21 +3315,6 @@
             "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/concat-stream": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
-            "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
-            "engines": [
-                "node >= 6.0"
-            ],
-            "license": "MIT",
-            "dependencies": {
-                "buffer-from": "^1.0.0",
-                "inherits": "^2.0.3",
-                "readable-stream": "^3.0.2",
-                "typedarray": "^0.0.6"
-            }
         },
         "node_modules/concurrently": {
             "version": "8.2.2",
@@ -5108,24 +4797,6 @@
             "integrity": "sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw==",
             "license": "MIT"
         },
-        "node_modules/file-type": {
-            "version": "21.3.4",
-            "resolved": "https://registry.npmjs.org/file-type/-/file-type-21.3.4.tgz",
-            "integrity": "sha512-Ievi/yy8DS3ygGvT47PjSfdFoX+2isQueoYP1cntFW1JLYAuS4GD7NUPGg4zv2iZfV52uDyk5w5Z0TdpRS6Q1g==",
-            "license": "MIT",
-            "dependencies": {
-                "@tokenizer/inflate": "^0.4.1",
-                "strtok3": "^10.3.4",
-                "token-types": "^6.1.1",
-                "uint8array-extras": "^1.4.0"
-            },
-            "engines": {
-                "node": ">=20"
-            },
-            "funding": {
-                "url": "https://github.com/sindresorhus/file-type?sponsor=1"
-            }
-        },
         "node_modules/file-uri-to-path": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
@@ -5818,12 +5489,6 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/idb-keyval": {
-            "version": "6.2.2",
-            "resolved": "https://registry.npmjs.org/idb-keyval/-/idb-keyval-6.2.2.tgz",
-            "integrity": "sha512-yjD9nARJ/jb1g+CvD0tlhUHOrJ9Sy0P8T9MF3YaLlHnSRpwPfpTX0XIvpmw3gAJUmEu3FiICLBDPXVwyEvrleg==",
-            "license": "Apache-2.0"
-        },
         "node_modules/ieee754": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
@@ -6377,12 +6042,6 @@
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
-        },
-        "node_modules/is-url": {
-            "version": "1.2.4",
-            "resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.4.tgz",
-            "integrity": "sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==",
-            "license": "MIT"
         },
         "node_modules/is-weakmap": {
             "version": "2.0.2",
@@ -7457,13 +7116,6 @@
                 "node": ">=18"
             }
         },
-        "node_modules/node-readable-to-web-readable-stream": {
-            "version": "0.4.2",
-            "resolved": "https://registry.npmjs.org/node-readable-to-web-readable-stream/-/node-readable-to-web-readable-stream-0.4.2.tgz",
-            "integrity": "sha512-/cMZNI34v//jUTrI+UIo4ieHAB5EZRY/+7OmXZgBxaWBMcW2tGdceIw06RFxWxrKZ5Jp3sI2i5TsRo+CBhtVLQ==",
-            "license": "MIT",
-            "optional": true
-        },
         "node_modules/node-releases": {
             "version": "2.0.19",
             "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz",
@@ -7723,39 +7375,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/officeparser": {
-            "version": "6.0.7",
-            "resolved": "https://registry.npmjs.org/officeparser/-/officeparser-6.0.7.tgz",
-            "integrity": "sha512-MkNHyWIfEZRDtB8c0fgJHdb4Ui0I/WztBjlUjlPiEbTO6dIYaJMt+llS5p5Foj13guUZgGxkkM9VwsVRthHNAA==",
-            "license": "MIT",
-            "dependencies": {
-                "@xmldom/xmldom": "^0.8.11",
-                "concat-stream": "^2.0.0",
-                "file-type": "^21.3.4",
-                "pdfjs-dist": "^5.5.207",
-                "tesseract.js": "^7.0.0",
-                "yauzl": "^3.2.1"
-            },
-            "bin": {
-                "officeparser": "dist/index.js"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "node_modules/officeparser/node_modules/yauzl": {
-            "version": "3.3.0",
-            "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-3.3.0.tgz",
-            "integrity": "sha512-PtGEvEP30p7sbIBJKUBjUnqgTVOyMURc4dLo9iNyAJnNIEz9pm88cCXF21w94Kg3k6RXkeZh5DHOGS0qEONvNQ==",
-            "license": "MIT",
-            "dependencies": {
-                "buffer-crc32": "~0.2.3",
-                "pend": "~1.2.0"
-            },
-            "engines": {
-                "node": ">=12"
-            }
-        },
         "node_modules/on-finished": {
             "version": "2.4.1",
             "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
@@ -7809,15 +7428,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/opencollective-postinstall": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/opencollective-postinstall/-/opencollective-postinstall-2.0.3.tgz",
-            "integrity": "sha512-8AV/sCtuzUeTo8gQK5qDZzARrulB3egtLzFgteqB2tcT4Mw7B8Kt7JcDHmltjz6FOAHsvTevk70gZEbhM4ZS9Q==",
-            "license": "MIT",
-            "bin": {
-                "opencollective-postinstall": "index.js"
             }
         },
         "node_modules/option": {
@@ -7940,19 +7550,6 @@
             "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
             "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
             "license": "MIT"
-        },
-        "node_modules/pdfjs-dist": {
-            "version": "5.6.205",
-            "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-5.6.205.tgz",
-            "integrity": "sha512-tlUj+2IDa7G1SbvBNN74UHRLJybZDWYom+k6p5KIZl7huBvsA4APi6mKL+zCxd3tLjN5hOOEE9Tv7VdzO88pfg==",
-            "license": "Apache-2.0",
-            "engines": {
-                "node": ">=20.19.0 || >=22.13.0 || >=24"
-            },
-            "optionalDependencies": {
-                "@napi-rs/canvas": "^0.1.96",
-                "node-readable-to-web-readable-stream": "^0.4.2"
-            }
         },
         "node_modules/pend": {
             "version": "1.2.0",
@@ -10102,22 +9699,6 @@
                 "node": ">=6"
             }
         },
-        "node_modules/strtok3": {
-            "version": "10.3.5",
-            "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-10.3.5.tgz",
-            "integrity": "sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA==",
-            "license": "MIT",
-            "dependencies": {
-                "@tokenizer/token": "^0.3.0"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/Borewit"
-            }
-        },
         "node_modules/supports-color": {
             "version": "7.2.0",
             "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -10253,36 +9834,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/tesseract.js": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/tesseract.js/-/tesseract.js-7.0.0.tgz",
-            "integrity": "sha512-exPBkd+z+wM1BuMkx/Bjv43OeLBxhL5kKWsz/9JY+DXcXdiBjiAch0V49QR3oAJqCaL5qURE0vx9Eo+G5YE7mA==",
-            "hasInstallScript": true,
-            "license": "Apache-2.0",
-            "dependencies": {
-                "bmp-js": "^0.1.0",
-                "idb-keyval": "^6.2.0",
-                "is-url": "^1.2.4",
-                "node-fetch": "^2.6.9",
-                "opencollective-postinstall": "^2.0.3",
-                "regenerator-runtime": "^0.13.3",
-                "tesseract.js-core": "^7.0.0",
-                "wasm-feature-detect": "^1.8.0",
-                "zlibjs": "^0.3.1"
-            }
-        },
-        "node_modules/tesseract.js-core": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/tesseract.js-core/-/tesseract.js-core-7.0.0.tgz",
-            "integrity": "sha512-WnNH518NzmbSq9zgTPeoF8c+xmilS8rFIl1YKbk/ptuuc7p6cLNELNuPAzcmsYw450ca6bLa8j3t0VAtq435Vw==",
-            "license": "Apache-2.0"
-        },
-        "node_modules/tesseract.js/node_modules/regenerator-runtime": {
-            "version": "0.13.11",
-            "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
-            "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
-            "license": "MIT"
-        },
         "node_modules/text-hex": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
@@ -10350,24 +9901,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">=0.6"
-            }
-        },
-        "node_modules/token-types": {
-            "version": "6.1.2",
-            "resolved": "https://registry.npmjs.org/token-types/-/token-types-6.1.2.tgz",
-            "integrity": "sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww==",
-            "license": "MIT",
-            "dependencies": {
-                "@borewit/text-codec": "^0.2.1",
-                "@tokenizer/token": "^0.3.0",
-                "ieee754": "^1.2.1"
-            },
-            "engines": {
-                "node": ">=14.16"
-            },
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/Borewit"
             }
         },
         "node_modules/touch": {
@@ -10550,12 +10083,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/typedarray": {
-            "version": "0.0.6",
-            "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-            "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
-            "license": "MIT"
-        },
         "node_modules/uid-safe": {
             "version": "2.1.5",
             "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-2.1.5.tgz",
@@ -10566,18 +10093,6 @@
             },
             "engines": {
                 "node": ">= 0.8"
-            }
-        },
-        "node_modules/uint8array-extras": {
-            "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/uint8array-extras/-/uint8array-extras-1.5.0.tgz",
-            "integrity": "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/unbox-primitive": {
@@ -10802,12 +10317,6 @@
             "engines": {
                 "node": ">=0.10.48"
             }
-        },
-        "node_modules/wasm-feature-detect": {
-            "version": "1.8.0",
-            "resolved": "https://registry.npmjs.org/wasm-feature-detect/-/wasm-feature-detect-1.8.0.tgz",
-            "integrity": "sha512-zksaLKM2fVlnB5jQQDqKXXwYHLQUVH9es+5TOOHwGOVJOCeRBCiPjwSg+3tN2AdTCzjgli4jijCH290kXb/zWQ==",
-            "license": "Apache-2.0"
         },
         "node_modules/webidl-conversions": {
             "version": "3.0.1",
@@ -11250,15 +10759,6 @@
             "dependencies": {
                 "buffer-crc32": "~0.2.3",
                 "fd-slicer": "~1.1.0"
-            }
-        },
-        "node_modules/zlibjs": {
-            "version": "0.3.1",
-            "resolved": "https://registry.npmjs.org/zlibjs/-/zlibjs-0.3.1.tgz",
-            "integrity": "sha512-+J9RrgTKOmlxFSDHo0pI1xM6BLVUv+o0ZT9ANtCxGkjIVCCUdx9alUF8Gm+dGLKbkkkidWIHFDZHDMpfITt4+w==",
-            "license": "MIT",
-            "engines": {
-                "node": "*"
             }
         }
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,12 +35,14 @@
                 "node-cache": "^5.1.2",
                 "node-fetch": "^2.7.0",
                 "node-gyp": "^11.2.0",
+                "officeparser": "^6.0.7",
                 "pg": "^8.11.3",
                 "pg-pool": "^3.6.2",
                 "pptxgenjs": "^4.0.1",
                 "sqlite3": "^5.1.6",
                 "uuid": "^9.0.1",
                 "winston": "^3.17.0",
+                "word-extractor": "^1.0.4",
                 "xml2js": "^0.6.2"
             },
             "devDependencies": {
@@ -1664,6 +1666,16 @@
                 "node": ">=6.9.0"
             }
         },
+        "node_modules/@borewit/text-codec": {
+            "version": "0.2.2",
+            "resolved": "https://registry.npmjs.org/@borewit/text-codec/-/text-codec-0.2.2.tgz",
+            "integrity": "sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ==",
+            "license": "MIT",
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/Borewit"
+            }
+        },
         "node_modules/@colors/colors": {
             "version": "1.6.0",
             "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.6.0.tgz",
@@ -1838,6 +1850,256 @@
                 }
             }
         },
+        "node_modules/@napi-rs/canvas": {
+            "version": "0.1.97",
+            "resolved": "https://registry.npmjs.org/@napi-rs/canvas/-/canvas-0.1.97.tgz",
+            "integrity": "sha512-8cFniXvrIEnVwuNSRCW9wirRZbHvrD3JVujdS2P5n5xiJZNZMOZcfOvJ1pb66c7jXMKHHglJEDVJGbm8XWFcXQ==",
+            "license": "MIT",
+            "optional": true,
+            "workspaces": [
+                "e2e/*"
+            ],
+            "engines": {
+                "node": ">= 10"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/Brooooooklyn"
+            },
+            "optionalDependencies": {
+                "@napi-rs/canvas-android-arm64": "0.1.97",
+                "@napi-rs/canvas-darwin-arm64": "0.1.97",
+                "@napi-rs/canvas-darwin-x64": "0.1.97",
+                "@napi-rs/canvas-linux-arm-gnueabihf": "0.1.97",
+                "@napi-rs/canvas-linux-arm64-gnu": "0.1.97",
+                "@napi-rs/canvas-linux-arm64-musl": "0.1.97",
+                "@napi-rs/canvas-linux-riscv64-gnu": "0.1.97",
+                "@napi-rs/canvas-linux-x64-gnu": "0.1.97",
+                "@napi-rs/canvas-linux-x64-musl": "0.1.97",
+                "@napi-rs/canvas-win32-arm64-msvc": "0.1.97",
+                "@napi-rs/canvas-win32-x64-msvc": "0.1.97"
+            }
+        },
+        "node_modules/@napi-rs/canvas-android-arm64": {
+            "version": "0.1.97",
+            "resolved": "https://registry.npmjs.org/@napi-rs/canvas-android-arm64/-/canvas-android-arm64-0.1.97.tgz",
+            "integrity": "sha512-V1c/WVw+NzH8vk7ZK/O8/nyBSCQimU8sfMsB/9qeSvdkGKNU7+mxy/bIF0gTgeBFmHpj30S4E9WHMSrxXGQuVQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">= 10"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/Brooooooklyn"
+            }
+        },
+        "node_modules/@napi-rs/canvas-darwin-arm64": {
+            "version": "0.1.97",
+            "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-arm64/-/canvas-darwin-arm64-0.1.97.tgz",
+            "integrity": "sha512-ok+SCEF4YejcxuJ9Rm+WWunHHpf2HmiPxfz6z1a/NFQECGXtsY7A4B8XocK1LmT1D7P174MzwPF9Wy3AUAwEPw==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">= 10"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/Brooooooklyn"
+            }
+        },
+        "node_modules/@napi-rs/canvas-darwin-x64": {
+            "version": "0.1.97",
+            "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-x64/-/canvas-darwin-x64-0.1.97.tgz",
+            "integrity": "sha512-PUP6e6/UGlclUvAQNnuXCcnkpdUou6VYZfQOQxExLp86epOylmiwLkqXIvpFmjoTEDmPmXrI+coL/9EFU1gKPA==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">= 10"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/Brooooooklyn"
+            }
+        },
+        "node_modules/@napi-rs/canvas-linux-arm-gnueabihf": {
+            "version": "0.1.97",
+            "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm-gnueabihf/-/canvas-linux-arm-gnueabihf-0.1.97.tgz",
+            "integrity": "sha512-XyXH2L/cic8eTNtbrXCcvqHtMX/nEOxN18+7rMrAM2XtLYC/EB5s0wnO1FsLMWmK+04ZSLN9FBGipo7kpIkcOw==",
+            "cpu": [
+                "arm"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 10"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/Brooooooklyn"
+            }
+        },
+        "node_modules/@napi-rs/canvas-linux-arm64-gnu": {
+            "version": "0.1.97",
+            "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-gnu/-/canvas-linux-arm64-gnu-0.1.97.tgz",
+            "integrity": "sha512-Kuq/M3djq0K8ktgz6nPlK7Ne5d4uWeDxPpyKWOjWDK2RIOhHVtLtyLiJw2fuldw7Vn4mhw05EZXCEr4Q76rs9w==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 10"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/Brooooooklyn"
+            }
+        },
+        "node_modules/@napi-rs/canvas-linux-arm64-musl": {
+            "version": "0.1.97",
+            "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-musl/-/canvas-linux-arm64-musl-0.1.97.tgz",
+            "integrity": "sha512-kKmSkQVnWeqg7qdsiXvYxKhAFuHz3tkBjW/zyQv5YKUPhotpaVhpBGv5LqCngzyuRV85SXoe+OFj+Tv0a0QXkQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 10"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/Brooooooklyn"
+            }
+        },
+        "node_modules/@napi-rs/canvas-linux-riscv64-gnu": {
+            "version": "0.1.97",
+            "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-riscv64-gnu/-/canvas-linux-riscv64-gnu-0.1.97.tgz",
+            "integrity": "sha512-Jc7I3A51jnEOIAXeLsN/M/+Z28LUeakcsXs07FLq9prXc0eYOtVwsDEv913Gr+06IRo34gJJVgT0TXvmz+N2VA==",
+            "cpu": [
+                "riscv64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 10"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/Brooooooklyn"
+            }
+        },
+        "node_modules/@napi-rs/canvas-linux-x64-gnu": {
+            "version": "0.1.97",
+            "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-gnu/-/canvas-linux-x64-gnu-0.1.97.tgz",
+            "integrity": "sha512-iDUBe7AilfuBSRbSa8/IGX38Mf+iCSBqoVKLSQ5XaY2JLOaqz1TVyPFEyIck7wT6mRQhQt5sN6ogfjIDfi74tg==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 10"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/Brooooooklyn"
+            }
+        },
+        "node_modules/@napi-rs/canvas-linux-x64-musl": {
+            "version": "0.1.97",
+            "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-musl/-/canvas-linux-x64-musl-0.1.97.tgz",
+            "integrity": "sha512-AKLFd/v0Z5fvgqBDqhvqtAdx+fHMJ5t9JcUNKq4FIZ5WH+iegGm8HPdj00NFlCSnm83Fp3Ln8I2f7uq1aIiWaA==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 10"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/Brooooooklyn"
+            }
+        },
+        "node_modules/@napi-rs/canvas-win32-arm64-msvc": {
+            "version": "0.1.97",
+            "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-arm64-msvc/-/canvas-win32-arm64-msvc-0.1.97.tgz",
+            "integrity": "sha512-u883Yr6A6fO7Vpsy9YE4FVCIxzzo5sO+7pIUjjoDLjS3vQaNMkVzx5bdIpEL+ob+gU88WDK4VcxYMZ6nmnoX9A==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">= 10"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/Brooooooklyn"
+            }
+        },
+        "node_modules/@napi-rs/canvas-win32-x64-msvc": {
+            "version": "0.1.97",
+            "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-x64-msvc/-/canvas-win32-x64-msvc-0.1.97.tgz",
+            "integrity": "sha512-sWtD2EE3fV0IzN+iiQUqr/Q1SwqWhs2O1FKItFlxtdDkikpEj5g7DKQpY3x55H/MAOnL8iomnlk3mcEeGiUMoQ==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">= 10"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/Brooooooklyn"
+            }
+        },
         "node_modules/@npmcli/agent": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/@npmcli/agent/-/agent-3.0.0.tgz",
@@ -1942,6 +2204,29 @@
             "resolved": "https://registry.npmjs.org/@sideway/pinpoint/-/pinpoint-2.0.0.tgz",
             "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==",
             "license": "BSD-3-Clause"
+        },
+        "node_modules/@tokenizer/inflate": {
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/@tokenizer/inflate/-/inflate-0.4.1.tgz",
+            "integrity": "sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA==",
+            "license": "MIT",
+            "dependencies": {
+                "debug": "^4.4.3",
+                "token-types": "^6.1.1"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/Borewit"
+            }
+        },
+        "node_modules/@tokenizer/token": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
+            "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==",
+            "license": "MIT"
         },
         "node_modules/@types/http-proxy": {
             "version": "1.17.16",
@@ -2521,6 +2806,12 @@
             "integrity": "sha512-iD3898SR7sWVRHbiQv+sHUtHnMvC1o3nW5rAcqnq3uOn07DSAppZYUkIGslDz6gXC7HfunPe7YVBgoEJASPcHA==",
             "license": "MIT"
         },
+        "node_modules/bmp-js": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/bmp-js/-/bmp-js-0.1.0.tgz",
+            "integrity": "sha512-vHdS19CnY3hwiNdkaqk93DvjVLfbEcI8mys4UjuWrlX1haDmroo8o4xCzh4wD6DGV6HxRCyauwhHRqMTfERtjw==",
+            "license": "MIT"
+        },
         "node_modules/body-parser": {
             "version": "2.2.2",
             "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
@@ -2803,11 +3094,26 @@
                 "ieee754": "^1.1.13"
             }
         },
+        "node_modules/buffer-crc32": {
+            "version": "0.2.13",
+            "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+            "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+            "license": "MIT",
+            "engines": {
+                "node": "*"
+            }
+        },
         "node_modules/buffer-equal-constant-time": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
             "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
             "license": "BSD-3-Clause"
+        },
+        "node_modules/buffer-from": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+            "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+            "license": "MIT"
         },
         "node_modules/builtins": {
             "version": "5.1.0",
@@ -3305,6 +3611,21 @@
             "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/concat-stream": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
+            "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
+            "engines": [
+                "node >= 6.0"
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "buffer-from": "^1.0.0",
+                "inherits": "^2.0.3",
+                "readable-stream": "^3.0.2",
+                "typedarray": "^0.0.6"
+            }
         },
         "node_modules/concurrently": {
             "version": "8.2.2",
@@ -4772,11 +5093,38 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/fd-slicer": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+            "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
+            "license": "MIT",
+            "dependencies": {
+                "pend": "~1.2.0"
+            }
+        },
         "node_modules/fecha": {
             "version": "4.2.3",
             "resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.3.tgz",
             "integrity": "sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw==",
             "license": "MIT"
+        },
+        "node_modules/file-type": {
+            "version": "21.3.4",
+            "resolved": "https://registry.npmjs.org/file-type/-/file-type-21.3.4.tgz",
+            "integrity": "sha512-Ievi/yy8DS3ygGvT47PjSfdFoX+2isQueoYP1cntFW1JLYAuS4GD7NUPGg4zv2iZfV52uDyk5w5Z0TdpRS6Q1g==",
+            "license": "MIT",
+            "dependencies": {
+                "@tokenizer/inflate": "^0.4.1",
+                "strtok3": "^10.3.4",
+                "token-types": "^6.1.1",
+                "uint8array-extras": "^1.4.0"
+            },
+            "engines": {
+                "node": ">=20"
+            },
+            "funding": {
+                "url": "https://github.com/sindresorhus/file-type?sponsor=1"
+            }
         },
         "node_modules/file-uri-to-path": {
             "version": "1.0.0",
@@ -5470,6 +5818,12 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/idb-keyval": {
+            "version": "6.2.2",
+            "resolved": "https://registry.npmjs.org/idb-keyval/-/idb-keyval-6.2.2.tgz",
+            "integrity": "sha512-yjD9nARJ/jb1g+CvD0tlhUHOrJ9Sy0P8T9MF3YaLlHnSRpwPfpTX0XIvpmw3gAJUmEu3FiICLBDPXVwyEvrleg==",
+            "license": "Apache-2.0"
+        },
         "node_modules/ieee754": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
@@ -6023,6 +6377,12 @@
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
+        },
+        "node_modules/is-url": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.4.tgz",
+            "integrity": "sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==",
+            "license": "MIT"
         },
         "node_modules/is-weakmap": {
             "version": "2.0.2",
@@ -7097,6 +7457,13 @@
                 "node": ">=18"
             }
         },
+        "node_modules/node-readable-to-web-readable-stream": {
+            "version": "0.4.2",
+            "resolved": "https://registry.npmjs.org/node-readable-to-web-readable-stream/-/node-readable-to-web-readable-stream-0.4.2.tgz",
+            "integrity": "sha512-/cMZNI34v//jUTrI+UIo4ieHAB5EZRY/+7OmXZgBxaWBMcW2tGdceIw06RFxWxrKZ5Jp3sI2i5TsRo+CBhtVLQ==",
+            "license": "MIT",
+            "optional": true
+        },
         "node_modules/node-releases": {
             "version": "2.0.19",
             "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz",
@@ -7356,6 +7723,39 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/officeparser": {
+            "version": "6.0.7",
+            "resolved": "https://registry.npmjs.org/officeparser/-/officeparser-6.0.7.tgz",
+            "integrity": "sha512-MkNHyWIfEZRDtB8c0fgJHdb4Ui0I/WztBjlUjlPiEbTO6dIYaJMt+llS5p5Foj13guUZgGxkkM9VwsVRthHNAA==",
+            "license": "MIT",
+            "dependencies": {
+                "@xmldom/xmldom": "^0.8.11",
+                "concat-stream": "^2.0.0",
+                "file-type": "^21.3.4",
+                "pdfjs-dist": "^5.5.207",
+                "tesseract.js": "^7.0.0",
+                "yauzl": "^3.2.1"
+            },
+            "bin": {
+                "officeparser": "dist/index.js"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/officeparser/node_modules/yauzl": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-3.3.0.tgz",
+            "integrity": "sha512-PtGEvEP30p7sbIBJKUBjUnqgTVOyMURc4dLo9iNyAJnNIEz9pm88cCXF21w94Kg3k6RXkeZh5DHOGS0qEONvNQ==",
+            "license": "MIT",
+            "dependencies": {
+                "buffer-crc32": "~0.2.3",
+                "pend": "~1.2.0"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
         "node_modules/on-finished": {
             "version": "2.4.1",
             "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
@@ -7409,6 +7809,15 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/opencollective-postinstall": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/opencollective-postinstall/-/opencollective-postinstall-2.0.3.tgz",
+            "integrity": "sha512-8AV/sCtuzUeTo8gQK5qDZzARrulB3egtLzFgteqB2tcT4Mw7B8Kt7JcDHmltjz6FOAHsvTevk70gZEbhM4ZS9Q==",
+            "license": "MIT",
+            "bin": {
+                "opencollective-postinstall": "index.js"
             }
         },
         "node_modules/option": {
@@ -7530,6 +7939,25 @@
             "version": "0.1.12",
             "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
             "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
+            "license": "MIT"
+        },
+        "node_modules/pdfjs-dist": {
+            "version": "5.6.205",
+            "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-5.6.205.tgz",
+            "integrity": "sha512-tlUj+2IDa7G1SbvBNN74UHRLJybZDWYom+k6p5KIZl7huBvsA4APi6mKL+zCxd3tLjN5hOOEE9Tv7VdzO88pfg==",
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=20.19.0 || >=22.13.0 || >=24"
+            },
+            "optionalDependencies": {
+                "@napi-rs/canvas": "^0.1.96",
+                "node-readable-to-web-readable-stream": "^0.4.2"
+            }
+        },
+        "node_modules/pend": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+            "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
             "license": "MIT"
         },
         "node_modules/pg": {
@@ -8423,6 +8851,18 @@
             "license": "BlueOak-1.0.0",
             "engines": {
                 "node": ">=11.0.0"
+            }
+        },
+        "node_modules/saxes": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/saxes/-/saxes-5.0.1.tgz",
+            "integrity": "sha512-5LBh1Tls8c9xgGjw3QrMwETmTMVk0oFgvrFSvWx62llR2hcEInrKNZ2GZCCuuy2lvWrdl5jhbpeqc5hRYKFOcw==",
+            "license": "ISC",
+            "dependencies": {
+                "xmlchars": "^2.2.0"
+            },
+            "engines": {
+                "node": ">=10"
             }
         },
         "node_modules/semver": {
@@ -9662,6 +10102,22 @@
                 "node": ">=6"
             }
         },
+        "node_modules/strtok3": {
+            "version": "10.3.5",
+            "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-10.3.5.tgz",
+            "integrity": "sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA==",
+            "license": "MIT",
+            "dependencies": {
+                "@tokenizer/token": "^0.3.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/Borewit"
+            }
+        },
         "node_modules/supports-color": {
             "version": "7.2.0",
             "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -9797,6 +10253,36 @@
                 "node": ">=8"
             }
         },
+        "node_modules/tesseract.js": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/tesseract.js/-/tesseract.js-7.0.0.tgz",
+            "integrity": "sha512-exPBkd+z+wM1BuMkx/Bjv43OeLBxhL5kKWsz/9JY+DXcXdiBjiAch0V49QR3oAJqCaL5qURE0vx9Eo+G5YE7mA==",
+            "hasInstallScript": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "bmp-js": "^0.1.0",
+                "idb-keyval": "^6.2.0",
+                "is-url": "^1.2.4",
+                "node-fetch": "^2.6.9",
+                "opencollective-postinstall": "^2.0.3",
+                "regenerator-runtime": "^0.13.3",
+                "tesseract.js-core": "^7.0.0",
+                "wasm-feature-detect": "^1.8.0",
+                "zlibjs": "^0.3.1"
+            }
+        },
+        "node_modules/tesseract.js-core": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/tesseract.js-core/-/tesseract.js-core-7.0.0.tgz",
+            "integrity": "sha512-WnNH518NzmbSq9zgTPeoF8c+xmilS8rFIl1YKbk/ptuuc7p6cLNELNuPAzcmsYw450ca6bLa8j3t0VAtq435Vw==",
+            "license": "Apache-2.0"
+        },
+        "node_modules/tesseract.js/node_modules/regenerator-runtime": {
+            "version": "0.13.11",
+            "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+            "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
+            "license": "MIT"
+        },
         "node_modules/text-hex": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
@@ -9864,6 +10350,24 @@
             "license": "MIT",
             "engines": {
                 "node": ">=0.6"
+            }
+        },
+        "node_modules/token-types": {
+            "version": "6.1.2",
+            "resolved": "https://registry.npmjs.org/token-types/-/token-types-6.1.2.tgz",
+            "integrity": "sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww==",
+            "license": "MIT",
+            "dependencies": {
+                "@borewit/text-codec": "^0.2.1",
+                "@tokenizer/token": "^0.3.0",
+                "ieee754": "^1.2.1"
+            },
+            "engines": {
+                "node": ">=14.16"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/Borewit"
             }
         },
         "node_modules/touch": {
@@ -10046,6 +10550,12 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/typedarray": {
+            "version": "0.0.6",
+            "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+            "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
+            "license": "MIT"
+        },
         "node_modules/uid-safe": {
             "version": "2.1.5",
             "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-2.1.5.tgz",
@@ -10056,6 +10566,18 @@
             },
             "engines": {
                 "node": ">= 0.8"
+            }
+        },
+        "node_modules/uint8array-extras": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/uint8array-extras/-/uint8array-extras-1.5.0.tgz",
+            "integrity": "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/unbox-primitive": {
@@ -10281,6 +10803,12 @@
                 "node": ">=0.10.48"
             }
         },
+        "node_modules/wasm-feature-detect": {
+            "version": "1.8.0",
+            "resolved": "https://registry.npmjs.org/wasm-feature-detect/-/wasm-feature-detect-1.8.0.tgz",
+            "integrity": "sha512-zksaLKM2fVlnB5jQQDqKXXwYHLQUVH9es+5TOOHwGOVJOCeRBCiPjwSg+3tN2AdTCzjgli4jijCH290kXb/zWQ==",
+            "license": "Apache-2.0"
+        },
         "node_modules/webidl-conversions": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
@@ -10488,6 +11016,16 @@
                 "node": ">= 12.0.0"
             }
         },
+        "node_modules/word-extractor": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/word-extractor/-/word-extractor-1.0.4.tgz",
+            "integrity": "sha512-PyAGZQ2gjnVA5kcZAOAxoYciCMaAvu0dbVlw/zxHphhy+3be8cDeYKHJPO8iedIM3Sx0arA/ugKTJyXhZNgo6g==",
+            "license": "MIT",
+            "dependencies": {
+                "saxes": "^5.0.1",
+                "yauzl": "^2.10.0"
+            }
+        },
         "node_modules/wrap-ansi": {
             "version": "8.1.0",
             "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
@@ -10644,6 +11182,12 @@
                 "node": ">=4.0"
             }
         },
+        "node_modules/xmlchars": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+            "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+            "license": "MIT"
+        },
         "node_modules/xtend": {
             "version": "4.0.2",
             "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
@@ -10696,6 +11240,25 @@
             "license": "ISC",
             "engines": {
                 "node": ">=12"
+            }
+        },
+        "node_modules/yauzl": {
+            "version": "2.10.0",
+            "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+            "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+            "license": "MIT",
+            "dependencies": {
+                "buffer-crc32": "~0.2.3",
+                "fd-slicer": "~1.1.0"
+            }
+        },
+        "node_modules/zlibjs": {
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/zlibjs/-/zlibjs-0.3.1.tgz",
+            "integrity": "sha512-+J9RrgTKOmlxFSDHo0pI1xM6BLVUv+o0ZT9ANtCxGkjIVCCUdx9alUF8Gm+dGLKbkkkidWIHFDZHDMpfITt4+w==",
+            "license": "MIT",
+            "engines": {
+                "node": "*"
             }
         }
     }

--- a/package.json
+++ b/package.json
@@ -38,12 +38,14 @@
         "node-cache": "^5.1.2",
         "node-fetch": "^2.7.0",
         "node-gyp": "^11.2.0",
+        "officeparser": "^6.0.7",
         "pg": "^8.11.3",
         "pg-pool": "^3.6.2",
         "pptxgenjs": "^4.0.1",
         "sqlite3": "^5.1.6",
         "uuid": "^9.0.1",
         "winston": "^3.17.0",
+        "word-extractor": "^1.0.4",
         "xml2js": "^0.6.2"
     },
     "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
         "node-cache": "^5.1.2",
         "node-fetch": "^2.7.0",
         "node-gyp": "^11.2.0",
-        "officeparser": "^6.0.7",
         "pg": "^8.11.3",
         "pg-pool": "^3.6.2",
         "pptxgenjs": "^4.0.1",

--- a/src/core/tools-service.cjs
+++ b/src/core/tools-service.cjs
@@ -1096,7 +1096,7 @@ This endpoint uses Microsoft Graph's calendarView which properly expands recurri
                 };
                 break;
             case 'downloadFile':
-                toolDef.description = 'Download a file from OneDrive or SharePoint';
+                toolDef.description = 'Download raw file bytes from OneDrive. Returns base64 binary. For Office documents, prefer: wordDocument (action:read) for .docx, powerpointPresentation (action:read) for .pptx, or excelRange for .xlsx — these return structured text instead of raw bytes.';
                 toolDef.endpoint = '/api/v1/files/download';
                 toolDef.method = 'GET';
                 toolDef.parameters = {
@@ -1126,7 +1126,7 @@ This endpoint uses Microsoft Graph's calendarView which properly expands recurri
                 };
                 break;
             case 'getFileContent':
-                toolDef.description = 'Get the content of a specific file. Use search with entityTypes: ["driveItem"] or listFiles to find the file ID.';
+                toolDef.description = 'Get raw file content as base64 bytes. Best for text files and CSVs. For Office documents, prefer: wordDocument (action:read) for .docx/.doc, powerpointPresentation (action:read) for .pptx, excelRange for .xlsx — these extract structured text.';
                 toolDef.endpoint = '/api/v1/files/content';
                 toolDef.method = 'GET';
                 toolDef.parameters = {

--- a/src/graph/powerpoint-service.cjs
+++ b/src/graph/powerpoint-service.cjs
@@ -227,49 +227,39 @@ async function readPresentation(fileId, req, userId, sessionId) {
       throw new Error(`File size ${size} bytes exceeds maximum allowed size of ${MAX_FILE_SIZE} bytes`);
     }
 
+    // Strategy: Try Graph HTML conversion first (works for ALL formats),
+    // fall back to jszip binary parsing only if Graph fails.
     const client = await graphClientFactory.createClient(req, resolvedUserId, resolvedSessionId);
-    const downloadResult = await client.api(`/me/drive/items/${fileId}/content`, resolvedUserId, resolvedSessionId).get();
 
-    // Ensure we have a binary Buffer
-    let buffer;
-    if (Buffer.isBuffer(downloadResult)) {
-      buffer = downloadResult;
-    } else if (typeof downloadResult === 'string') {
-      buffer = Buffer.from(downloadResult, 'binary');
-    } else {
-      buffer = null;
-    }
-
-    const isOpenXml = buffer && buffer.length >= 4 && buffer.slice(0, 2).toString() === 'PK';
-
-    if (!isOpenXml) {
-      // Not Open XML — fall back to Graph HTML conversion for legacy .ppt and other formats
-      MonitoringService.info('PowerPoint is not Open XML, using Graph HTML conversion fallback', {
-        fileId, headerHex: buffer ? buffer.slice(0, 4).toString('hex') : 'null'
-      }, 'powerpoint');
-
-      let text = '';
-      try {
-        const htmlResult = await client.api(`/me/drive/items/${fileId}/content?format=html`, resolvedUserId, resolvedSessionId).get();
-        const html = Buffer.isBuffer(htmlResult) ? htmlResult.toString('utf8') : (typeof htmlResult === 'string' ? htmlResult : '');
-        text = html.replace(/<[^>]+>/g, ' ').replace(/\s+/g, ' ').trim();
-      } catch (convErr) {
-        // Graph can't convert this format — return file info with webUrl
-        const meta = await client.api(`/me/drive/items/${fileId}`, resolvedUserId, resolvedSessionId).get();
-        text = `Unable to extract content from this presentation format. File: ${meta.name}, Size: ${meta.size} bytes. Open in browser: ${meta.webUrl}`;
+    // Attempt 1: Graph server-side HTML conversion
+    try {
+      const htmlResult = await client.api(`/me/drive/items/${fileId}/content?format=html`, resolvedUserId, resolvedSessionId).get();
+      const html = Buffer.isBuffer(htmlResult) ? htmlResult.toString('utf8') : (typeof htmlResult === 'string' ? htmlResult : '');
+      if (html && html.length > 0) {
+        const text = html.replace(/<[^>]+>/g, ' ').replace(/\s+/g, ' ').trim();
+        // Try to count slides from the HTML (each slide typically generates a section)
+        const slideMatches = html.match(/<div[^>]*class="[^"]*slide[^"]*"/gi) || [];
+        MonitoringService.trackMetric('powerpoint_read_success', Date.now() - startTime, { fileId, method: 'graph-html', userId: resolvedUserId });
+        return {
+          slideCount: slideMatches.length || null,
+          slides: [{ index: 1, texts: [text.substring(0, 10000)] }],
+          _format: 'graph-html'
+        };
       }
-
-      return {
-        slideCount: null,
-        slides: [{ index: 1, texts: [text.substring(0, 5000)], _note: 'Converted via Graph (file is not Open XML format)' }],
-        _format: 'html-fallback'
-      };
+    } catch (graphErr) {
+      MonitoringService.debug('Graph HTML conversion failed, trying jszip fallback', { fileId, error: graphErr.message }, 'powerpoint');
     }
 
-    const zip = await JSZip.loadAsync(buffer);
+    // Attempt 2: Download binary and parse with jszip (for true .pptx Open XML files)
+    try {
+      const downloadResult = await client.api(`/me/drive/items/${fileId}/content`, resolvedUserId, resolvedSessionId).get();
+      const buffer = Buffer.isBuffer(downloadResult) ? downloadResult : (typeof downloadResult === 'string' ? Buffer.from(downloadResult, 'binary') : null);
 
-    // Find and sort slide XML files
-    const slideFiles = Object.keys(zip.files)
+      if (buffer && buffer.length >= 4 && buffer.slice(0, 2).toString() === 'PK') {
+        const zip = await JSZip.loadAsync(buffer);
+
+        // Find and sort slide XML files
+        const slideFiles = Object.keys(zip.files)
       .filter(f => f.match(/^ppt\/slides\/slide\d+\.xml$/))
       .sort((a, b) => {
         const numA = parseInt(a.match(/slide(\d+)\.xml$/)[1], 10);
@@ -277,33 +267,28 @@ async function readPresentation(fileId, req, userId, sessionId) {
         return numA - numB;
       });
 
-    const slides = [];
-    for (let i = 0; i < slideFiles.length; i++) {
-      const xml = await zip.file(slideFiles[i]).async('string');
-      const parsed = await parseStringPromise(xml);
-      const texts = extractTexts(parsed);
-      slides.push({ index: i + 1, texts });
+        const slides = [];
+        for (let i = 0; i < slideFiles.length; i++) {
+          const xml = await zip.file(slideFiles[i]).async('string');
+          const parsed = await parseStringPromise(xml);
+          const texts = extractTexts(parsed);
+          slides.push({ index: i + 1, texts });
+        }
+        MonitoringService.trackMetric('powerpoint_read_success', Date.now() - startTime, { fileId, method: 'jszip', slideCount: slides.length, userId: resolvedUserId });
+        return { slideCount: slides.length, slides };
+      }
+    } catch (jszipErr) {
+      MonitoringService.debug('jszip fallback also failed', { fileId, error: jszipErr.message }, 'powerpoint');
     }
 
-    const executionTime = Date.now() - startTime;
-
-    if (resolvedUserId) {
-      MonitoringService.info('PowerPoint read successfully', {
-        fileId,
-        slideCount: slides.length,
-        executionTimeMs: executionTime,
-        timestamp: new Date().toISOString()
-      }, 'powerpoint', null, resolvedUserId);
-    }
-
-    MonitoringService.trackMetric('powerpoint_read_success', executionTime, {
-      fileId,
-      slideCount: slides.length,
-      userId: resolvedUserId,
-      timestamp: new Date().toISOString()
-    });
-
-    return { slideCount: slides.length, slides };
+    // Attempt 3: Return file metadata with webUrl
+    const meta = await client.api(`/me/drive/items/${fileId}`, resolvedUserId, resolvedSessionId).get();
+    MonitoringService.trackMetric('powerpoint_read_fallback', Date.now() - startTime, { fileId, userId: resolvedUserId });
+    return {
+      slideCount: null,
+      slides: [{ index: 1, texts: [`Unable to extract content. Open in browser: ${meta.webUrl}`] }],
+      _format: 'fallback'
+    };
   } catch (error) {
     const executionTime = Date.now() - startTime;
     const mcpError = ErrorService.createError(

--- a/src/graph/powerpoint-service.cjs
+++ b/src/graph/powerpoint-service.cjs
@@ -248,10 +248,16 @@ async function readPresentation(fileId, req, userId, sessionId) {
         fileId, headerHex: buffer ? buffer.slice(0, 4).toString('hex') : 'null'
       }, 'powerpoint');
 
-      const htmlResult = await client.api(`/me/drive/items/${fileId}/content?format=html`, resolvedUserId, resolvedSessionId).get();
-      const html = Buffer.isBuffer(htmlResult) ? htmlResult.toString('utf8') : (typeof htmlResult === 'string' ? htmlResult : '');
-      // Extract text from HTML
-      const text = html.replace(/<[^>]+>/g, ' ').replace(/\s+/g, ' ').trim();
+      let text = '';
+      try {
+        const htmlResult = await client.api(`/me/drive/items/${fileId}/content?format=html`, resolvedUserId, resolvedSessionId).get();
+        const html = Buffer.isBuffer(htmlResult) ? htmlResult.toString('utf8') : (typeof htmlResult === 'string' ? htmlResult : '');
+        text = html.replace(/<[^>]+>/g, ' ').replace(/\s+/g, ' ').trim();
+      } catch (convErr) {
+        // Graph can't convert this format — return file info with webUrl
+        const meta = await client.api(`/me/drive/items/${fileId}`, resolvedUserId, resolvedSessionId).get();
+        text = `Unable to extract content from this presentation format. File: ${meta.name}, Size: ${meta.size} bytes. Open in browser: ${meta.webUrl}`;
+      }
 
       return {
         slideCount: null,

--- a/src/graph/powerpoint-service.cjs
+++ b/src/graph/powerpoint-service.cjs
@@ -230,22 +230,34 @@ async function readPresentation(fileId, req, userId, sessionId) {
     const client = await graphClientFactory.createClient(req, resolvedUserId, resolvedSessionId);
     const downloadResult = await client.api(`/me/drive/items/${fileId}/content`, resolvedUserId, resolvedSessionId).get();
 
-    // Ensure we have a valid binary Buffer
+    // Ensure we have a binary Buffer
     let buffer;
     if (Buffer.isBuffer(downloadResult)) {
       buffer = downloadResult;
     } else if (typeof downloadResult === 'string') {
       buffer = Buffer.from(downloadResult, 'binary');
-    } else if (downloadResult && typeof downloadResult === 'object') {
-      throw new Error(`Download returned object instead of binary: ${JSON.stringify(downloadResult).substring(0, 200)}`);
     } else {
-      throw new Error(`Unexpected download result type: ${typeof downloadResult}`);
+      buffer = null;
     }
 
-    // Validate zip header (pptx = zip with PK header)
-    if (buffer.length < 4 || buffer.slice(0, 2).toString() !== 'PK') {
-      const preview = buffer.slice(0, 100).toString('utf8').replace(/[^\x20-\x7E]/g, '.');
-      throw new Error(`Downloaded content is not a valid .pptx file (expected PK zip header, got ${buffer.slice(0,4).toString('hex')}). Preview: ${preview}`);
+    const isOpenXml = buffer && buffer.length >= 4 && buffer.slice(0, 2).toString() === 'PK';
+
+    if (!isOpenXml) {
+      // Not Open XML — fall back to Graph HTML conversion for legacy .ppt and other formats
+      MonitoringService.info('PowerPoint is not Open XML, using Graph HTML conversion fallback', {
+        fileId, headerHex: buffer ? buffer.slice(0, 4).toString('hex') : 'null'
+      }, 'powerpoint');
+
+      const htmlResult = await client.api(`/me/drive/items/${fileId}/content?format=html`, resolvedUserId, resolvedSessionId).get();
+      const html = Buffer.isBuffer(htmlResult) ? htmlResult.toString('utf8') : (typeof htmlResult === 'string' ? htmlResult : '');
+      // Extract text from HTML
+      const text = html.replace(/<[^>]+>/g, ' ').replace(/\s+/g, ' ').trim();
+
+      return {
+        slideCount: null,
+        slides: [{ index: 1, texts: [text.substring(0, 5000)], _note: 'Converted via Graph (file is not Open XML format)' }],
+        _format: 'html-fallback'
+      };
     }
 
     const zip = await JSZip.loadAsync(buffer);
@@ -432,29 +444,37 @@ async function getPresentationMetadata(fileId, req, userId, sessionId) {
     const graphMeta = await client.api(`/me/drive/items/${fileId}`, resolvedUserId, resolvedSessionId).get();
     const downloadResult = await client.api(`/me/drive/items/${fileId}/content`, resolvedUserId, resolvedSessionId).get();
     const buffer = Buffer.isBuffer(downloadResult) ? downloadResult : (typeof downloadResult === 'string' ? Buffer.from(downloadResult, 'binary') : null);
-    if (!buffer || buffer.length < 4 || buffer.slice(0, 2).toString() !== 'PK') {
-      throw new Error(`Downloaded content is not a valid .pptx (got ${buffer ? buffer.slice(0,4).toString('hex') : 'null'})`);
-    }
-    const zip = await JSZip.loadAsync(buffer);
+    const isOpenXml = buffer && buffer.length >= 4 && buffer.slice(0, 2).toString() === 'PK';
 
-    // Count slides
-    const slideCount = Object.keys(zip.files)
-      .filter(f => f.match(/^ppt\/slides\/slide\d+\.xml$/))
-      .length;
-
-    // Extract core properties
-    const coreXml = await zip.file('docProps/core.xml')?.async('string');
+    let slideCount = null;
     let docProps = {};
-    if (coreXml) {
-      const parsed = await parseStringPromise(coreXml);
-      const props = parsed['cp:coreProperties'] || parsed['coreProperties'] || {};
-      docProps = {
-        title: props['dc:title']?.[0] || props['title']?.[0] || null,
-        creator: props['dc:creator']?.[0] || props['creator']?.[0] || null,
+
+    if (isOpenXml) {
+      const zip = await JSZip.loadAsync(buffer);
+      slideCount = Object.keys(zip.files).filter(f => f.match(/^ppt\/slides\/slide\d+\.xml$/)).length;
+      const coreXml = await zip.file('docProps/core.xml')?.async('string');
+      if (coreXml) {
+        const parsed = await parseStringPromise(coreXml);
+        const props = parsed['cp:coreProperties'] || parsed['coreProperties'] || {};
+        docProps = {
+          title: props['dc:title']?.[0] || props['title']?.[0] || null,
+          creator: props['dc:creator']?.[0] || props['creator']?.[0] || null,
         created: props['dcterms:created']?.[0]?._ || props['dcterms:created']?.[0] || null,
         modified: props['dcterms:modified']?.[0]?._ || props['dcterms:modified']?.[0] || null,
         description: props['dc:description']?.[0] || props['description']?.[0] || null,
         keywords: props['cp:keywords']?.[0] || props['keywords']?.[0] || null
+        };
+      }
+    } else {
+      // Legacy format — use Graph metadata
+      docProps = {
+        title: graphMeta.name?.replace(/\.[^.]+$/, '') || null,
+        creator: graphMeta.createdBy?.user?.displayName || null,
+        created: graphMeta.createdDateTime || null,
+        modified: graphMeta.lastModifiedDateTime || null,
+        description: null,
+        keywords: null,
+        _note: 'Metadata from Graph (file is not Open XML format)'
       };
     }
 
@@ -464,7 +484,7 @@ async function getPresentationMetadata(fileId, req, userId, sessionId) {
       MonitoringService.info('PowerPoint metadata retrieved', {
         fileId,
         slideCount,
-        hasDocProps: !!coreXml,
+        isOpenXml,
         executionTimeMs: executionTime,
         timestamp: new Date().toISOString()
       }, 'powerpoint', null, resolvedUserId);

--- a/src/graph/powerpoint-service.cjs
+++ b/src/graph/powerpoint-service.cjs
@@ -250,15 +250,16 @@ async function readPresentation(fileId, req, userId, sessionId) {
       MonitoringService.debug('Graph HTML conversion failed, trying jszip fallback', { fileId, error: graphErr.message }, 'powerpoint');
     }
 
-    // Attempt 2: Download binary via @microsoft.graph.downloadUrl and parse with jszip
+    // Attempt 2: Download binary via /contentStream (beta) and parse with jszip
+    // The /contentStream endpoint returns 200 with raw binary directly (no 302 redirect)
+    // See: https://learn.microsoft.com/en-us/graph/api/driveitem-get-contentstream
     try {
-      const driveItem = await client.api(`/me/drive/items/${fileId}`, resolvedUserId, resolvedSessionId).get();
-      const downloadUrl = driveItem['@microsoft.graph.downloadUrl'];
+      const downloadResult = await client.api(`/me/drive/items/${fileId}/contentStream`, resolvedUserId, resolvedSessionId).version('beta').get();
       let buffer = null;
-      if (downloadUrl) {
-        const fetch = require('node-fetch');
-        const dlResponse = await fetch(downloadUrl);
-        buffer = await dlResponse.buffer();
+      if (Buffer.isBuffer(downloadResult)) {
+        buffer = downloadResult;
+      } else if (typeof downloadResult === 'string') {
+        buffer = Buffer.from(downloadResult, 'binary');
       }
 
       if (buffer && buffer.length >= 4 && buffer.slice(0, 2).toString() === 'PK') {

--- a/src/graph/powerpoint-service.cjs
+++ b/src/graph/powerpoint-service.cjs
@@ -250,10 +250,16 @@ async function readPresentation(fileId, req, userId, sessionId) {
       MonitoringService.debug('Graph HTML conversion failed, trying jszip fallback', { fileId, error: graphErr.message }, 'powerpoint');
     }
 
-    // Attempt 2: Download binary and parse with jszip (for true .pptx Open XML files)
+    // Attempt 2: Download binary via @microsoft.graph.downloadUrl and parse with jszip
     try {
-      const downloadResult = await client.api(`/me/drive/items/${fileId}/content`, resolvedUserId, resolvedSessionId).get();
-      const buffer = Buffer.isBuffer(downloadResult) ? downloadResult : (typeof downloadResult === 'string' ? Buffer.from(downloadResult, 'binary') : null);
+      const driveItem = await client.api(`/me/drive/items/${fileId}`, resolvedUserId, resolvedSessionId).get();
+      const downloadUrl = driveItem['@microsoft.graph.downloadUrl'];
+      let buffer = null;
+      if (downloadUrl) {
+        const fetch = require('node-fetch');
+        const dlResponse = await fetch(downloadUrl);
+        buffer = await dlResponse.buffer();
+      }
 
       if (buffer && buffer.length >= 4 && buffer.slice(0, 2).toString() === 'PK') {
         const zip = await JSZip.loadAsync(buffer);

--- a/src/graph/powerpoint-service.cjs
+++ b/src/graph/powerpoint-service.cjs
@@ -437,10 +437,15 @@ async function getPresentationMetadata(fileId, req, userId, sessionId) {
       throw new Error(`File size ${size} bytes exceeds maximum allowed size of ${MAX_FILE_SIZE} bytes`);
     }
 
-    // Get Graph file metadata and download content
+    // Get Graph file metadata and download content via /contentStream (beta)
     const client = await graphClientFactory.createClient(req, resolvedUserId, resolvedSessionId);
     const graphMeta = await client.api(`/me/drive/items/${fileId}`, resolvedUserId, resolvedSessionId).get();
-    const downloadResult = await client.api(`/me/drive/items/${fileId}/content`, resolvedUserId, resolvedSessionId).get();
+    let downloadResult = null;
+    try {
+      downloadResult = await client.api(`/me/drive/items/${fileId}/contentStream`, resolvedUserId, resolvedSessionId).version('beta').get();
+    } catch (dlErr) {
+      MonitoringService.debug('contentStream failed for PPT metadata', { fileId, error: dlErr.message }, 'powerpoint');
+    }
     const buffer = Buffer.isBuffer(downloadResult) ? downloadResult : (typeof downloadResult === 'string' ? Buffer.from(downloadResult, 'binary') : null);
     const isOpenXml = buffer && buffer.length >= 4 && buffer.slice(0, 2).toString() === 'PK';
 

--- a/src/graph/word-service.cjs
+++ b/src/graph/word-service.cjs
@@ -210,86 +210,44 @@ async function readWordDocument(fileId, req, userId, sessionId) {
       throw new Error(`File size ${size} bytes exceeds maximum allowed size of ${MAX_FILE_SIZE} bytes`);
     }
 
+    // Strategy: Try Graph HTML conversion first (works for ALL formats — .doc, .docx,
+    // SharePoint-converted files). Falls back to mammoth binary parsing only if Graph fails.
     const client = await graphClientFactory.createClient(req, resolvedUserId, resolvedSessionId);
-    const downloadResult = await client.api(`/me/drive/items/${fileId}/content`, resolvedUserId, resolvedSessionId).get();
 
-    // Ensure we have a Buffer for mammoth/jszip
-    let buffer;
-    if (Buffer.isBuffer(downloadResult)) {
-      buffer = downloadResult;
-    } else if (typeof downloadResult === 'string') {
-      buffer = Buffer.from(downloadResult, 'binary');
-    } else if (downloadResult && typeof downloadResult === 'object') {
-      // Graph might return a JSON error or redirect response instead of binary
-      throw new Error(`Download returned object instead of binary: ${JSON.stringify(downloadResult).substring(0, 200)}`);
-    } else {
-      throw new Error(`Unexpected download result type: ${typeof downloadResult}`);
-    }
-
-    // Check if the file is a valid Open XML zip (PK header)
-    const isOpenXml = buffer.length >= 4 && buffer.slice(0, 2).toString() === 'PK';
-
-    if (!isOpenXml) {
-      // Not a .docx (Open XML) — likely a legacy .doc, encrypted file, or other format
-      // Fall back to Graph's server-side HTML conversion which handles all Office formats
-      MonitoringService.info('Word doc is not Open XML (header: ' + buffer.slice(0, 4).toString('hex') + '), using Graph HTML conversion fallback', {
-        fileId, headerHex: buffer.slice(0, 4).toString('hex')
-      }, 'word');
-
-      let html = '', text = '', warnings = ['File is not in Open XML (.docx) format'];
-      try {
-        const htmlResult = await client.api(`/me/drive/items/${fileId}/content?format=html`, resolvedUserId, resolvedSessionId).get();
-        html = Buffer.isBuffer(htmlResult) ? htmlResult.toString('utf8') : (typeof htmlResult === 'string' ? htmlResult : '');
-        text = html.replace(/<[^>]+>/g, ' ').replace(/\s+/g, ' ').trim();
-        warnings.push('Read via Graph HTML conversion');
-      } catch (convErr) {
-        // Graph can't convert this format (406 notSupported) — return what we know from metadata
-        const meta = await client.api(`/me/drive/items/${fileId}`, resolvedUserId, resolvedSessionId).get();
-        html = `<p>Unable to extract content from this file format. File: ${meta.name}, Size: ${meta.size} bytes. <a href="${meta.webUrl}">Open in browser</a></p>`;
-        text = `Unable to extract content from this file format. File: ${meta.name}, Size: ${meta.size} bytes. Open in browser: ${meta.webUrl}`;
-        warnings.push('Graph conversion not supported for this file format — use the webUrl to open in browser');
+    // Attempt 1: Graph server-side HTML conversion
+    try {
+      const htmlResult = await client.api(`/me/drive/items/${fileId}/content?format=html`, resolvedUserId, resolvedSessionId).get();
+      const html = Buffer.isBuffer(htmlResult) ? htmlResult.toString('utf8') : (typeof htmlResult === 'string' ? htmlResult : '');
+      if (html && html.length > 0) {
+        const text = html.replace(/<[^>]+>/g, ' ').replace(/\s+/g, ' ').trim();
+        MonitoringService.trackMetric('word_read_success', Date.now() - startTime, { fileId, method: 'graph-html', userId: resolvedUserId });
+        return { html, text, warnings: [] };
       }
+    } catch (graphErr) {
+      MonitoringService.debug('Graph HTML conversion failed, trying mammoth fallback', { fileId, error: graphErr.message }, 'word');
+    }
 
-      const executionTime = Date.now() - startTime;
-      if (resolvedUserId) {
-        MonitoringService.info('Word document read via fallback', {
-          fileId, htmlLength: html.length, executionTimeMs: executionTime
-        }, 'word', null, resolvedUserId);
+    // Attempt 2: Download binary and parse with mammoth (for true .docx files when Graph conversion is unavailable)
+    try {
+      const downloadResult = await client.api(`/me/drive/items/${fileId}/content`, resolvedUserId, resolvedSessionId).get();
+      const buffer = Buffer.isBuffer(downloadResult) ? downloadResult : (typeof downloadResult === 'string' ? Buffer.from(downloadResult, 'binary') : null);
+
+      if (buffer && buffer.length >= 4 && buffer.slice(0, 2).toString() === 'PK') {
+        const result = await mammoth.convertToHtml({ buffer });
+        const textResult = await mammoth.extractRawText({ buffer });
+        MonitoringService.trackMetric('word_read_success', Date.now() - startTime, { fileId, method: 'mammoth', userId: resolvedUserId });
+        return { html: result.value, text: textResult.value, warnings: result.messages };
       }
-
-      return { html, text, warnings: ['File was not in .docx format — read via Graph server-side conversion'] };
+    } catch (mammothErr) {
+      MonitoringService.debug('Mammoth fallback also failed', { fileId, error: mammothErr.message }, 'word');
     }
 
-    MonitoringService.debug('Word doc download buffer info', {
-      isBuffer: true, length: buffer.length, firstBytes: buffer.slice(0, 4).toString('hex'), isZip: true
-    }, 'word');
-
-    const result = await mammoth.convertToHtml({ buffer });
-    const textResult = await mammoth.extractRawText({ buffer });
-
-    const executionTime = Date.now() - startTime;
-
-    if (resolvedUserId) {
-      MonitoringService.info('Word document read successfully', {
-        fileId,
-        htmlLength: result.value.length,
-        textLength: textResult.value.length,
-        executionTimeMs: executionTime,
-        timestamp: new Date().toISOString()
-      }, 'word', null, resolvedUserId);
-    }
-
-    MonitoringService.trackMetric('word_read_success', executionTime, {
-      fileId,
-      userId: resolvedUserId,
-      timestamp: new Date().toISOString()
-    });
-
-    return {
-      html: result.value,
-      text: textResult.value,
-      warnings: result.messages
-    };
+    // Attempt 3: Return file metadata with webUrl so user can open in browser
+    const meta = await client.api(`/me/drive/items/${fileId}`, resolvedUserId, resolvedSessionId).get();
+    const fallbackHtml = `<p>Unable to extract content. <a href="${meta.webUrl}">Open ${meta.name} in browser</a></p>`;
+    const fallbackText = `Unable to extract content. Open in browser: ${meta.webUrl}`;
+    MonitoringService.trackMetric('word_read_fallback', Date.now() - startTime, { fileId, userId: resolvedUserId });
+    return { html: fallbackHtml, text: fallbackText, warnings: ['Content extraction not available — use the webUrl to open in browser'] };
   } catch (error) {
     const executionTime = Date.now() - startTime;
     const mcpError = ErrorService.createError(

--- a/src/graph/word-service.cjs
+++ b/src/graph/word-service.cjs
@@ -227,10 +227,17 @@ async function readWordDocument(fileId, req, userId, sessionId) {
       MonitoringService.debug('Graph HTML conversion failed, trying mammoth fallback', { fileId, error: graphErr.message }, 'word');
     }
 
-    // Attempt 2: Download binary and parse with mammoth (for true .docx files when Graph conversion is unavailable)
+    // Attempt 2: Download binary via @microsoft.graph.downloadUrl and parse with mammoth
+    // Using the pre-authenticated download URL avoids 302 redirect issues with node-fetch
     try {
-      const downloadResult = await client.api(`/me/drive/items/${fileId}/content`, resolvedUserId, resolvedSessionId).get();
-      const buffer = Buffer.isBuffer(downloadResult) ? downloadResult : (typeof downloadResult === 'string' ? Buffer.from(downloadResult, 'binary') : null);
+      const driveItem = await client.api(`/me/drive/items/${fileId}`, resolvedUserId, resolvedSessionId).get();
+      const downloadUrl = driveItem['@microsoft.graph.downloadUrl'];
+      let buffer = null;
+      if (downloadUrl) {
+        const fetch = require('node-fetch');
+        const dlResponse = await fetch(downloadUrl);
+        buffer = await dlResponse.buffer();
+      }
 
       if (buffer && buffer.length >= 4 && buffer.slice(0, 2).toString() === 'PK') {
         const result = await mammoth.convertToHtml({ buffer });

--- a/src/graph/word-service.cjs
+++ b/src/graph/word-service.cjs
@@ -227,16 +227,16 @@ async function readWordDocument(fileId, req, userId, sessionId) {
       MonitoringService.debug('Graph HTML conversion failed, trying mammoth fallback', { fileId, error: graphErr.message }, 'word');
     }
 
-    // Attempt 2: Download binary via @microsoft.graph.downloadUrl and parse with mammoth
-    // Using the pre-authenticated download URL avoids 302 redirect issues with node-fetch
+    // Attempt 2: Download binary via /contentStream (beta) and parse with mammoth
+    // The /contentStream endpoint returns 200 with raw binary directly (no 302 redirect)
+    // See: https://learn.microsoft.com/en-us/graph/api/driveitem-get-contentstream
     try {
-      const driveItem = await client.api(`/me/drive/items/${fileId}`, resolvedUserId, resolvedSessionId).get();
-      const downloadUrl = driveItem['@microsoft.graph.downloadUrl'];
+      const downloadResult = await client.api(`/me/drive/items/${fileId}/contentStream`, resolvedUserId, resolvedSessionId).version('beta').get();
       let buffer = null;
-      if (downloadUrl) {
-        const fetch = require('node-fetch');
-        const dlResponse = await fetch(downloadUrl);
-        buffer = await dlResponse.buffer();
+      if (Buffer.isBuffer(downloadResult)) {
+        buffer = downloadResult;
+      } else if (typeof downloadResult === 'string') {
+        buffer = Buffer.from(downloadResult, 'binary');
       }
 
       if (buffer && buffer.length >= 4 && buffer.slice(0, 2).toString() === 'PK') {

--- a/src/graph/word-service.cjs
+++ b/src/graph/word-service.cjs
@@ -272,6 +272,7 @@ async function readWordDocument(fileId, req, userId, sessionId) {
           MonitoringService.debug('mammoth also failed', { fileId, error: mErr.message }, 'word');
         }
       }
+
     }
 
     // Attempt 3: Return file metadata with webUrl so user can open in browser
@@ -572,8 +573,9 @@ async function getWordDocumentAsHtml(fileId, req, userId, sessionId) {
     }
 
     let html, warnings = [];
+    let isOpenXml = false;
     if (buffer && buffer.length > 0) {
-      const isOpenXml = buffer.slice(0, 2).toString() === 'PK';
+      isOpenXml = buffer.slice(0, 2).toString() === 'PK';
 
       // Attempt 1: mammoth (best HTML quality, .docx only)
       if (isOpenXml) {

--- a/src/graph/word-service.cjs
+++ b/src/graph/word-service.cjs
@@ -6,7 +6,9 @@
 
 const { Document, Packer, Paragraph, TextRun, HeadingLevel, Table, TableRow, TableCell, AlignmentType, ImageRun } = require('docx');
 const mammoth = require('mammoth');
+const WordExtractor = require('word-extractor');
 const JSZip = require('jszip');
+const wordExtractor = new WordExtractor();
 const { parseStringPromise } = require('xml2js');
 const graphClientFactory = require('./graph-client.cjs');
 const filesService = require('./files-service.cjs');
@@ -210,43 +212,66 @@ async function readWordDocument(fileId, req, userId, sessionId) {
       throw new Error(`File size ${size} bytes exceeds maximum allowed size of ${MAX_FILE_SIZE} bytes`);
     }
 
-    // Strategy: Try Graph HTML conversion first (works for ALL formats — .doc, .docx,
-    // SharePoint-converted files). Falls back to mammoth binary parsing only if Graph fails.
+    // Strategy:
+    // 1. Download binary via /contentStream (beta) — returns raw bytes without 302 redirect
+    // 2. Try word-extractor (handles both .doc OLE2 and .docx Open XML)
+    // 3. If word-extractor fails, try mammoth (better HTML quality for .docx)
+    // 4. Last resort: return webUrl
+    // See: https://learn.microsoft.com/en-us/graph/api/driveitem-get-contentstream
     const client = await graphClientFactory.createClient(req, resolvedUserId, resolvedSessionId);
 
-    // Attempt 1: Graph server-side HTML conversion
-    try {
-      const htmlResult = await client.api(`/me/drive/items/${fileId}/content?format=html`, resolvedUserId, resolvedSessionId).get();
-      const html = Buffer.isBuffer(htmlResult) ? htmlResult.toString('utf8') : (typeof htmlResult === 'string' ? htmlResult : '');
-      if (html && html.length > 0) {
-        const text = html.replace(/<[^>]+>/g, ' ').replace(/\s+/g, ' ').trim();
-        MonitoringService.trackMetric('word_read_success', Date.now() - startTime, { fileId, method: 'graph-html', userId: resolvedUserId });
-        return { html, text, warnings: [] };
-      }
-    } catch (graphErr) {
-      MonitoringService.debug('Graph HTML conversion failed, trying mammoth fallback', { fileId, error: graphErr.message }, 'word');
-    }
-
-    // Attempt 2: Download binary via /contentStream (beta) and parse with mammoth
-    // The /contentStream endpoint returns 200 with raw binary directly (no 302 redirect)
-    // See: https://learn.microsoft.com/en-us/graph/api/driveitem-get-contentstream
+    let buffer = null;
     try {
       const downloadResult = await client.api(`/me/drive/items/${fileId}/contentStream`, resolvedUserId, resolvedSessionId).version('beta').get();
-      let buffer = null;
       if (Buffer.isBuffer(downloadResult)) {
         buffer = downloadResult;
       } else if (typeof downloadResult === 'string') {
         buffer = Buffer.from(downloadResult, 'binary');
       }
+    } catch (dlErr) {
+      MonitoringService.debug('contentStream download failed', { fileId, error: dlErr.message }, 'word');
+    }
 
-      if (buffer && buffer.length >= 4 && buffer.slice(0, 2).toString() === 'PK') {
-        const result = await mammoth.convertToHtml({ buffer });
-        const textResult = await mammoth.extractRawText({ buffer });
-        MonitoringService.trackMetric('word_read_success', Date.now() - startTime, { fileId, method: 'mammoth', userId: resolvedUserId });
-        return { html: result.value, text: textResult.value, warnings: result.messages };
+    if (buffer && buffer.length > 0) {
+      // Attempt 1: word-extractor (handles .doc OLE2 AND .docx Open XML)
+      try {
+        const doc = await wordExtractor.extract(buffer);
+        const text = doc.getBody();
+        if (text && text.trim().length > 0) {
+          // Also try mammoth for HTML (only works on .docx/PK files)
+          let html = '';
+          if (buffer.slice(0, 2).toString() === 'PK') {
+            try {
+              const mammothResult = await mammoth.convertToHtml({ buffer });
+              html = mammothResult.value;
+            } catch (mErr) {
+              // mammoth failed — use text with basic HTML wrapping
+              html = text.split('\n').map(line => line.trim() ? `<p>${line}</p>` : '').join('\n');
+            }
+          } else {
+            // OLE2 file — wrap text as HTML paragraphs
+            html = text.split('\n').map(line => line.trim() ? `<p>${line}</p>` : '').join('\n');
+          }
+          MonitoringService.trackMetric('word_read_success', Date.now() - startTime, {
+            fileId, method: 'word-extractor', format: buffer.slice(0, 2).toString() === 'PK' ? 'docx' : 'doc', userId: resolvedUserId
+          });
+          return { html, text, warnings: [] };
+        }
+      } catch (weErr) {
+        MonitoringService.debug('word-extractor failed, trying mammoth', { fileId, error: weErr.message }, 'word');
       }
-    } catch (mammothErr) {
-      MonitoringService.debug('Mammoth fallback also failed', { fileId, error: mammothErr.message }, 'word');
+
+      // Attempt 2: mammoth only (if word-extractor failed but file is .docx)
+      if (buffer.slice(0, 2).toString() === 'PK') {
+        try {
+          const result = await mammoth.convertToHtml({ buffer });
+          const textResult = await mammoth.extractRawText({ buffer });
+          MonitoringService.trackMetric('word_read_success', Date.now() - startTime, { fileId, method: 'mammoth', userId: resolvedUserId });
+          return { html: result.value, text: textResult.value, warnings: result.messages };
+        } catch (mErr) {
+          MonitoringService.debug('mammoth also failed', { fileId, error: mErr.message }, 'word');
+        }
+      }
     }
 
     // Attempt 3: Return file metadata with webUrl so user can open in browser
@@ -396,12 +421,17 @@ async function getWordDocumentMetadata(fileId, req, userId, sessionId) {
       throw new Error(`File size ${size} bytes exceeds maximum allowed size of ${MAX_FILE_SIZE} bytes`);
     }
 
-    // Get Graph file metadata and download content
+    // Get Graph file metadata and download content via /contentStream (beta)
     const client = await graphClientFactory.createClient(req, resolvedUserId, resolvedSessionId);
     const graphMeta = await client.api(`/me/drive/items/${fileId}`, resolvedUserId, resolvedSessionId).get();
     // Try to extract docProps from Open XML, fall back to Graph metadata for non-zip files
     let docProps = {};
-    const downloadResult = await client.api(`/me/drive/items/${fileId}/content`, resolvedUserId, resolvedSessionId).get();
+    let downloadResult = null;
+    try {
+      downloadResult = await client.api(`/me/drive/items/${fileId}/contentStream`, resolvedUserId, resolvedSessionId).version('beta').get();
+    } catch (dlErr) {
+      MonitoringService.debug('contentStream failed for metadata', { fileId, error: dlErr.message }, 'word');
+    }
     const buffer = Buffer.isBuffer(downloadResult) ? downloadResult : (typeof downloadResult === 'string' ? Buffer.from(downloadResult, 'binary') : null);
     const isOpenXml = buffer && buffer.length >= 4 && buffer.slice(0, 2).toString() === 'PK';
 
@@ -522,27 +552,60 @@ async function getWordDocumentAsHtml(fileId, req, userId, sessionId) {
       throw new Error(`File size ${size} bytes exceeds maximum allowed size of ${MAX_FILE_SIZE} bytes`);
     }
 
+    // Strategy: same as readWordDocument
+    // 1. Download binary via /contentStream (beta) — returns raw bytes without 302 redirect
+    // 2. Try mammoth for best HTML quality (.docx only)
+    // 3. Try word-extractor + basic HTML wrapping (handles .doc OLE2 and .docx)
+    // 4. Last resort: return webUrl
     const client = await graphClientFactory.createClient(req, resolvedUserId, resolvedSessionId);
-    const downloadResult = await client.api(`/me/drive/items/${fileId}/content`, resolvedUserId, resolvedSessionId).get();
-    const buffer = Buffer.isBuffer(downloadResult) ? downloadResult : (typeof downloadResult === 'string' ? Buffer.from(downloadResult, 'binary') : downloadResult);
-    const isOpenXml = Buffer.isBuffer(buffer) && buffer.length >= 4 && buffer.slice(0, 2).toString() === 'PK';
+
+    let buffer = null;
+    try {
+      const downloadResult = await client.api(`/me/drive/items/${fileId}/contentStream`, resolvedUserId, resolvedSessionId).version('beta').get();
+      if (Buffer.isBuffer(downloadResult)) {
+        buffer = downloadResult;
+      } else if (typeof downloadResult === 'string') {
+        buffer = Buffer.from(downloadResult, 'binary');
+      }
+    } catch (dlErr) {
+      MonitoringService.debug('contentStream download failed for HTML conversion', { fileId, error: dlErr.message }, 'word');
+    }
 
     let html, warnings = [];
-    if (isOpenXml) {
-      const result = await mammoth.convertToHtml({ buffer });
-      html = result.value;
-      warnings = result.messages;
-    } else {
-      // Fall back to Graph HTML conversion for legacy/non-zip formats
-      try {
-        const htmlResult = await client.api(`/me/drive/items/${fileId}/content?format=html`, resolvedUserId, resolvedSessionId).get();
-        html = Buffer.isBuffer(htmlResult) ? htmlResult.toString('utf8') : (typeof htmlResult === 'string' ? htmlResult : '');
-        warnings = [{ message: 'Converted via Graph (file is not Open XML format)' }];
-      } catch (convErr) {
-        const meta = await client.api(`/me/drive/items/${fileId}`, resolvedUserId, resolvedSessionId).get();
-        html = `<p>Unable to convert this file format to HTML. File: ${meta.name}. <a href="${meta.webUrl}">Open in browser</a></p>`;
-        warnings = [{ message: 'Conversion not supported — use webUrl to open in browser' }];
+    if (buffer && buffer.length > 0) {
+      const isOpenXml = buffer.slice(0, 2).toString() === 'PK';
+
+      // Attempt 1: mammoth (best HTML quality, .docx only)
+      if (isOpenXml) {
+        try {
+          const result = await mammoth.convertToHtml({ buffer });
+          html = result.value;
+          warnings = result.messages;
+        } catch (mErr) {
+          MonitoringService.debug('mammoth HTML conversion failed', { fileId, error: mErr.message }, 'word');
+        }
       }
+
+      // Attempt 2: word-extractor (handles both .doc and .docx)
+      if (!html) {
+        try {
+          const doc = await wordExtractor.extract(buffer);
+          const text = doc.getBody();
+          if (text && text.trim().length > 0) {
+            html = text.split('\n').map(line => line.trim() ? `<p>${line}</p>` : '').join('\n');
+            warnings = [{ message: `Converted via word-extractor (${isOpenXml ? 'docx' : 'doc/OLE2'} format)` }];
+          }
+        } catch (weErr) {
+          MonitoringService.debug('word-extractor HTML conversion failed', { fileId, error: weErr.message }, 'word');
+        }
+      }
+    }
+
+    // Attempt 3: webUrl fallback
+    if (!html) {
+      const meta = await client.api(`/me/drive/items/${fileId}`, resolvedUserId, resolvedSessionId).get();
+      html = `<p>Unable to convert this file to HTML. <a href="${meta.webUrl}">Open ${meta.name} in browser</a></p>`;
+      warnings = [{ message: 'Content extraction not available — use webUrl to open in browser' }];
     }
 
     const executionTime = Date.now() - startTime;

--- a/src/graph/word-service.cjs
+++ b/src/graph/word-service.cjs
@@ -226,17 +226,42 @@ async function readWordDocument(fileId, req, userId, sessionId) {
       throw new Error(`Unexpected download result type: ${typeof downloadResult}`);
     }
 
-    // Validate the buffer is actually a zip file (docx = zip with PK header)
-    if (buffer.length < 4 || buffer.slice(0, 2).toString() !== 'PK') {
-      const preview = buffer.slice(0, 100).toString('utf8').replace(/[^\x20-\x7E]/g, '.');
-      throw new Error(`Downloaded content is not a valid .docx file (expected PK zip header, got ${buffer.slice(0,4).toString('hex')}). First 100 chars: ${preview}`);
+    // Check if the file is a valid Open XML zip (PK header)
+    const isOpenXml = buffer.length >= 4 && buffer.slice(0, 2).toString() === 'PK';
+
+    if (!isOpenXml) {
+      // Not a .docx (Open XML) — likely a legacy .doc, encrypted file, or other format
+      // Fall back to Graph's server-side HTML conversion which handles all Office formats
+      MonitoringService.info('Word doc is not Open XML (header: ' + buffer.slice(0, 4).toString('hex') + '), using Graph HTML conversion fallback', {
+        fileId, headerHex: buffer.slice(0, 4).toString('hex')
+      }, 'word');
+
+      let html = '', text = '', warnings = ['File is not in Open XML (.docx) format'];
+      try {
+        const htmlResult = await client.api(`/me/drive/items/${fileId}/content?format=html`, resolvedUserId, resolvedSessionId).get();
+        html = Buffer.isBuffer(htmlResult) ? htmlResult.toString('utf8') : (typeof htmlResult === 'string' ? htmlResult : '');
+        text = html.replace(/<[^>]+>/g, ' ').replace(/\s+/g, ' ').trim();
+        warnings.push('Read via Graph HTML conversion');
+      } catch (convErr) {
+        // Graph can't convert this format (406 notSupported) — return what we know from metadata
+        const meta = await client.api(`/me/drive/items/${fileId}`, resolvedUserId, resolvedSessionId).get();
+        html = `<p>Unable to extract content from this file format. File: ${meta.name}, Size: ${meta.size} bytes. <a href="${meta.webUrl}">Open in browser</a></p>`;
+        text = `Unable to extract content from this file format. File: ${meta.name}, Size: ${meta.size} bytes. Open in browser: ${meta.webUrl}`;
+        warnings.push('Graph conversion not supported for this file format — use the webUrl to open in browser');
+      }
+
+      const executionTime = Date.now() - startTime;
+      if (resolvedUserId) {
+        MonitoringService.info('Word document read via fallback', {
+          fileId, htmlLength: html.length, executionTimeMs: executionTime
+        }, 'word', null, resolvedUserId);
+      }
+
+      return { html, text, warnings: ['File was not in .docx format — read via Graph server-side conversion'] };
     }
 
     MonitoringService.debug('Word doc download buffer info', {
-      isBuffer: true,
-      length: buffer.length,
-      firstBytes: buffer.slice(0, 4).toString('hex'),
-      isZip: true
+      isBuffer: true, length: buffer.length, firstBytes: buffer.slice(0, 4).toString('hex'), isZip: true
     }, 'word');
 
     const result = await mammoth.convertToHtml({ buffer });
@@ -409,25 +434,37 @@ async function getWordDocumentMetadata(fileId, req, userId, sessionId) {
     // Get Graph file metadata and download content
     const client = await graphClientFactory.createClient(req, resolvedUserId, resolvedSessionId);
     const graphMeta = await client.api(`/me/drive/items/${fileId}`, resolvedUserId, resolvedSessionId).get();
+    // Try to extract docProps from Open XML, fall back to Graph metadata for non-zip files
+    let docProps = {};
     const downloadResult = await client.api(`/me/drive/items/${fileId}/content`, resolvedUserId, resolvedSessionId).get();
     const buffer = Buffer.isBuffer(downloadResult) ? downloadResult : (typeof downloadResult === 'string' ? Buffer.from(downloadResult, 'binary') : null);
-    if (!buffer || buffer.length < 4 || buffer.slice(0, 2).toString() !== 'PK') {
-      throw new Error(`Downloaded content is not a valid .docx (got ${buffer ? buffer.slice(0,4).toString('hex') : 'null'})`);
-    }
-    const zip = await JSZip.loadAsync(buffer);
-    const coreXml = await zip.file('docProps/core.xml')?.async('string');
+    const isOpenXml = buffer && buffer.length >= 4 && buffer.slice(0, 2).toString() === 'PK';
 
-    let docProps = {};
-    if (coreXml) {
-      const parsed = await parseStringPromise(coreXml);
-      const props = parsed['cp:coreProperties'] || parsed['coreProperties'] || {};
+    if (isOpenXml) {
+      const zip = await JSZip.loadAsync(buffer);
+      const coreXml = await zip.file('docProps/core.xml')?.async('string');
+      if (coreXml) {
+        const parsed = await parseStringPromise(coreXml);
+        const props = parsed['cp:coreProperties'] || parsed['coreProperties'] || {};
+        docProps = {
+          title: props['dc:title']?.[0] || props['title']?.[0] || null,
+          creator: props['dc:creator']?.[0] || props['creator']?.[0] || null,
+          created: props['dcterms:created']?.[0]?._ || props['dcterms:created']?.[0] || null,
+          modified: props['dcterms:modified']?.[0]?._ || props['dcterms:modified']?.[0] || null,
+          description: props['dc:description']?.[0] || props['description']?.[0] || null,
+          keywords: props['cp:keywords']?.[0] || props['keywords']?.[0] || null
+        };
+      }
+    } else {
+      // Legacy format — extract what we can from Graph driveItem metadata
       docProps = {
-        title: props['dc:title']?.[0] || props['title']?.[0] || null,
-        creator: props['dc:creator']?.[0] || props['creator']?.[0] || null,
-        created: props['dcterms:created']?.[0]?._ || props['dcterms:created']?.[0] || null,
-        modified: props['dcterms:modified']?.[0]?._ || props['dcterms:modified']?.[0] || null,
-        description: props['dc:description']?.[0] || props['description']?.[0] || null,
-        keywords: props['cp:keywords']?.[0] || props['keywords']?.[0] || null
+        title: graphMeta.name?.replace(/\.[^.]+$/, '') || null,
+        creator: graphMeta.createdBy?.user?.displayName || null,
+        created: graphMeta.createdDateTime || null,
+        modified: graphMeta.lastModifiedDateTime || null,
+        description: null,
+        keywords: null,
+        _note: 'Metadata extracted from Graph (file is not Open XML format)'
       };
     }
 
@@ -436,7 +473,7 @@ async function getWordDocumentMetadata(fileId, req, userId, sessionId) {
     if (resolvedUserId) {
       MonitoringService.info('Word document metadata retrieved', {
         fileId,
-        hasDocProps: !!coreXml,
+        isOpenXml,
         executionTimeMs: executionTime,
         timestamp: new Date().toISOString()
       }, 'word', null, resolvedUserId);
@@ -521,17 +558,33 @@ async function getWordDocumentAsHtml(fileId, req, userId, sessionId) {
     }
 
     const client = await graphClientFactory.createClient(req, resolvedUserId, resolvedSessionId);
-    const buffer = await client.api(`/me/drive/items/${fileId}/content`, resolvedUserId, resolvedSessionId).get();
-    const result = await mammoth.convertToHtml({ buffer });
+    const downloadResult = await client.api(`/me/drive/items/${fileId}/content`, resolvedUserId, resolvedSessionId).get();
+    const buffer = Buffer.isBuffer(downloadResult) ? downloadResult : (typeof downloadResult === 'string' ? Buffer.from(downloadResult, 'binary') : downloadResult);
+    const isOpenXml = Buffer.isBuffer(buffer) && buffer.length >= 4 && buffer.slice(0, 2).toString() === 'PK';
+
+    let html, warnings = [];
+    if (isOpenXml) {
+      const result = await mammoth.convertToHtml({ buffer });
+      html = result.value;
+      warnings = result.messages;
+    } else {
+      // Fall back to Graph HTML conversion for legacy/non-zip formats
+      try {
+        const htmlResult = await client.api(`/me/drive/items/${fileId}/content?format=html`, resolvedUserId, resolvedSessionId).get();
+        html = Buffer.isBuffer(htmlResult) ? htmlResult.toString('utf8') : (typeof htmlResult === 'string' ? htmlResult : '');
+        warnings = [{ message: 'Converted via Graph (file is not Open XML format)' }];
+      } catch (convErr) {
+        const meta = await client.api(`/me/drive/items/${fileId}`, resolvedUserId, resolvedSessionId).get();
+        html = `<p>Unable to convert this file format to HTML. File: ${meta.name}. <a href="${meta.webUrl}">Open in browser</a></p>`;
+        warnings = [{ message: 'Conversion not supported — use webUrl to open in browser' }];
+      }
+    }
 
     const executionTime = Date.now() - startTime;
 
     if (resolvedUserId) {
       MonitoringService.info('Word document converted to HTML', {
-        fileId,
-        htmlLength: result.value.length,
-        executionTimeMs: executionTime,
-        timestamp: new Date().toISOString()
+        fileId, htmlLength: html.length, fallback: !isOpenXml, executionTimeMs: executionTime
       }, 'word', null, resolvedUserId);
     }
 
@@ -541,10 +594,7 @@ async function getWordDocumentAsHtml(fileId, req, userId, sessionId) {
       timestamp: new Date().toISOString()
     });
 
-    return {
-      html: result.value,
-      warnings: result.messages
-    };
+    return { html, warnings };
   } catch (error) {
     const executionTime = Date.now() - startTime;
     const mcpError = ErrorService.createError(


### PR DESCRIPTION
## Summary

- **Word read fallback chain**: mammoth → word-extractor → webUrl (handles both .docx and .doc/OLE2 formats)
- **Migrate all binary downloads** from deprecated `/content` (302 redirect) to `/contentStream` (beta, raw binary)
- **MCP_MODULES filter** applied to server-fetched tool list (fixes Claude Desktop showing all tools)
- **Graceful degradation** for OLE2 files (SharePoint-converted) — returns webUrl instead of errors
- **README updated** with word-extractor docs, OLE2 note, MCP_DEBUG, detailed project structure

## Changes

**Word service** (`src/graph/word-service.cjs`):
- Add `word-extractor` library for .doc OLE2 support
- Rewrite `readWordDocument` with multi-library fallback chain
- Rewrite `getWordDocumentAsHtml` to use `/contentStream` + mammoth + word-extractor
- Update `getWordDocumentMetadata` to use `/contentStream`

**PowerPoint service** (`src/graph/powerpoint-service.cjs`):
- `readPresentation`: Graph HTML conversion → jszip fallback → webUrl
- `getPresentationMetadata`: migrate to `/contentStream`

**Adapter & tools** (`mcp-adapter.cjs`, `src/core/tools-service.cjs`):
- Fix MCP_MODULES filter for server-fetched tools
- Guide Claude toward dedicated Office tools instead of generic downloadFile

## Test plan
- [x] Word create → immediate read (fresh .docx, word-extractor extracts text)
- [x] Word read on OLE2 file (SharePoint-converted) → graceful webUrl fallback
- [x] Word metadata from both .docx and OLE2 formats
- [x] Word HTML conversion with mammoth (docx) and webUrl fallback (OLE2)
- [x] PowerPoint create → read → metadata (jszip parsing works)
- [x] All endpoints return 200, no unhandled errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)